### PR TITLE
Add Yakushima travel guide

### DIFF
--- a/docs/guides/yakushima.md
+++ b/docs/guides/yakushima.md
@@ -1,0 +1,181 @@
+# Yakushima Travel Guide
+
+## Key Locations to Check Out
+
+- [【ne-】 Plant-based Cafe & Act](https://maps.app.goo.gl/XToBR9pJqYpHR6RNA?g_st=in)
+  - Japanese: `【ne-】 プラントベースカフェ＆アクト`
+  - Description: A cozy plant-based cafe offering a variety of vegan and vegetarian dishes. Perfect for a healthy meal in a relaxing atmosphere.
+- [あさひ弁当](https://maps.app.goo.gl/zmpv4UCkuuhqPGYg6?g_st=in)
+  - Japanese: `あさひ弁当`
+  - Description: A popular bento shop known for its delicious and affordable lunch boxes. Great for a quick and tasty meal on the go.
+- [かたぎりさん](https://maps.app.goo.gl/KBbDiPCYQieMikoL9?g_st=in)
+  - Japanese: `かたぎりさん`
+  - Description: A local favorite restaurant offering a variety of traditional Japanese dishes. Known for its friendly service and cozy atmosphere.
+- [屋久島世界遺産センター](https://maps.app.goo.gl/nHhiCjQyMGE8xH7N7?g_st=in)
+  - Japanese: `屋久島世界遺産センター`
+  - Description: The Yakushima World Heritage Center provides information about the island's natural and cultural heritage. A great place to learn about Yakushima's unique ecosystem.
+- [白谷雲水峡](https://maps.app.goo.gl/k9pWsCxSdryeX31N6?g_st=in)
+  - Japanese: `白谷雲水峡`
+  - Description: Shiratani Unsuikyo is a lush, moss-covered forest that inspired the setting for Studio Ghibli's "Princess Mononoke." A must-visit for nature lovers and hikers.
+- [縄文の宿まんてん](https://maps.app.goo.gl/RcGRVikFdK5vHYCk8?g_st=in)
+  - Japanese: `縄文の宿まんてん`
+  - Description: A traditional Japanese inn offering comfortable accommodations and hot spring baths. Perfect for a relaxing stay on the island.
+- [縄文杉](https://maps.app.goo.gl/RwBr2ne4m7zWrc7f9?g_st=in)
+  - Japanese: `縄文杉`
+  - Description: Jomon Sugi is an ancient cedar tree estimated to be over 7,000 years old. It is one of the oldest and most famous trees in Japan.
+- [荒川登山バス停留所](https://maps.app.goo.gl/z5mzMdYGWmo5y4TH6?g_st=in)
+  - Japanese: `荒川登山バス停留所`
+  - Description: The Arakawa Tozan Bus Stop is the starting point for the hike to Jomon Sugi. It is accessible by bus from Yakushima's main towns.
+- [西部林道](https://maps.app.goo.gl/EswnXbsKE7MmKuLM9?g_st=in)
+  - Japanese: `西部林道`
+  - Description: The Seibu Rindo Forest Path is a scenic drive through Yakushima's western forests. It offers stunning views and opportunities to see wildlife.
+
+## References
+
+- [Yakushima Travel Guide - What to do on Yakushima Island](https://www.japan-guide.com/e/e4650.html)
+- [YES YAKUSHIMA – Yakushima Tours & FREE Booking Service](https://yesyakushima.com/)
+- [屋久島貸切エコツアー好奇心やくしま | 屋久島公認ガイド | 屋久島町](https://www.koukishin8940.com/)
+
+## Itinerary
+
+### ✈️ Haneda to Kagoshima
+
+- JAL 643 - 08:05 - 09:50
+
+### ✈️ Kagoshima to Yakushima
+
+- JAL 3745 - 11:20 - 12:00
+
+### Car Rental Pickup
+
+- Location: Yakushima Airport
+- Company: Times Car Rental
+- Google Maps: [Times Car Rental](https://maps.app.goo.gl/a5dGccP3Dn1PXbtMA)
+- [Times Car Rental Website](https://rental.timescar.jp/kagoshima/shop/4611/?layout=0&btn=0)
+
+### Hotel Check-in
+
+- Location: Yakushima Cottage, Forest Fairy
+- Google Maps: [Yakushima Cottage, Forest Fairy](https://maps.app.goo.gl/dBqmDxxg4t6gMzvh7)
+- [Booking.com](https://www.booking.com/Share-CpEumG)
+
+### Sat, Sep 28 - Yakushima
+
+#### Shiratani Unsuikyo Mossy Forest
+
+- 白谷雲水峡苔むす森
+- 苔むす森ツアー - 好奇心やくしま
+- [苔むす森ツアー | 好奇心やくしま](https://www.koukishin8940.com/%E8%8B%94%E3%82%80%E3%81%99%E6%A3%AE%E3%83%84%E3%82%A2%E3%83%BC)
+- [Instagram @koukishinyakushima](https://www.instagram.com/koukishinyakushima)
+- Relaxed 3-hour tour
+- 3.6 km round trip hiking
+- Path transitions from a well-maintained walkway to an old mountain trail dating back to the Edo period.
+
+#### Itinerary
+
+- 07:30 - Pick up at the hotel
+- 08:30 - Start hiking
+- 11:30 - Return to the trailhead
+
+#### Pricing
+
+- Forest Environment Conservation Contribution: 500 yen per person
+- Full-day tour -> 3 people: ¥10,000 per person (Total: ¥30,000)
+
+### Sun, Sep 29 - Yakushima - TBD
+
+- 45,000 - 縄文杉 (じょうもんすぎ)
+- 71,400
+
+### あさひ弁当
+
+- 090-2714-0329
+- [あさひ弁当](https://yakushima.co.jp/bento/)
+- Order bento
+
+### Mon, Sep 30 - Yakushima - Long Hike
+
+#### Jyomon sugi hike - Kae pick us up at 4:10 AM
+
+- JyomonスギHiking
+- 好奇心やくしま かえさん
+- 04:10 - Kaeーさんpicks us up at the hotel
+- Hotel to Yakusugi museum 屋久杉自然館 and take a bus
+- Tickets needed before hiking day 3,000 円pp [Yakushima Tozan](http://yakushima-tozan.com/bus/)
+
+#### 【行き】 屋久杉自然館前 荒川登山口
+
+- [Bound] In front of Yakusugi Nature Museum, Arakawa trailhead
+- Departs at 5:00 → Arrives at 5:35
+- Departs at 5:20 → Arrives at 5:55
+- Departs at 5:40 → Arrives at 6:15
+- Departs at 14:00 → Arrives at 14:35
+
+#### 【帰り】 荒川登山口 屋久杉自然館前
+
+- [Return] Arakawa trailhead, in front of Yakusugi Nature Museum
+- Departs at 6:20 → Arrives at 6:55
+- Departs at 15:00 → Arrives at 15:35
+- Departs at 16:00 → Arrives at 16:35
+- Departs at 16:30 → Arrives at 17:05
+- Departs at 17:00 → Arrives at 17:35
+- Departs at 17:45 → Arrives at 18:20
+
+#### 登山者の皆様へお知らせ（9/25）
+
+1. 荒川登山口から先のトイレ（バイオトイレ・大株歩道トイレ）は使用できません。携帯トイレをご準備ください。
+2. 町道淀川線は通行止めのため、淀川登山口には下山しないでください。
+
+#### Notice to All Hikers (9/25)
+
+1. Toilets beyond the Arakawa Trailhead (including the bio-toilet and Ōkabu Trail toilet) are currently out of service.
+2. Do not descend via Yodogawa Trailhead (Yodogawa Road is closed)
+
+#### 縄文杉ツアー - 好奇心やくしま - Hiking tour guide
+
+- [屋久島貸切エコツアー好奇心やくしま | 屋久島公認ガイド | 屋久島町](https://www.koukishin8940.com/)
+
+### Hirauchi Kaicyu onsen
+
+- 平内海中温泉
+- [Hirauchi Kaicyu onsen](https://maps.app.goo.gl/dRRM3odGmKhgygkX9)
+
+### Tue, Oct 1 - Yakushima - Kayak 🚣‍♀️
+
+#### 屋久島サウスアイランド
+
+- 畠中さん
+- 8,800 x 3 =26,400
+- 0997-49-7288
+
+### Shopping Center Ban Chan
+
+- Aコープ安房店（ショッピングセンターばんちゃん）
+- [Shopping Center Ban Chan](https://maps.app.goo.gl/R8x9cNpCYxUoqViEA)
+
+### Wed, Oct 2 - Head to Kagoshima
+
+- 11:00 - Forest Fairy Check-out
+- 16:00 Car Rental Return
+- Yakushima Airport - Times Car Rental
+- Return: 10/02 at 18:00 (JAL3756)
+
+### ✈️ Yakushima to Kagoshima
+
+- JAL 3756 - 19:00 - 19:35
+
+## About Yakushima Island
+
+Yakushima is a subtropical island located off the southern coast of Kyushu, Japan. It is known for its lush, ancient forests, diverse wildlife, and stunning natural beauty. The island is a UNESCO World Heritage site and offers a unique blend of outdoor activities, cultural experiences, and relaxation.
+
+### Key Notable Notes
+
+- Yakushima is home to some of the oldest trees in Japan, including the famous Jomon Sugi, which is estimated to be over 7,000 years old.
+- The island's diverse ecosystems range from coastal areas to high mountain peaks, providing a habitat for a wide variety of plant and animal species.
+- Yakushima's forests inspired the setting for Studio Ghibli's animated film "Princess Mononoke."
+
+## Tips for Visiting Yakushima
+
+- It rains a lot on Yakushima, so good rain gear is highly recommended.
+- Car rental is a must for getting around the island efficiently.
+- Hiking is amazing, but hiking poles and a tour guide are highly recommended for a safe and enjoyable experience.


### PR DESCRIPTION
Add a new travel guide entry for Yakushima.

- Add key locations to check out in Yakushima with English names, Japanese names, Google Maps links, and descriptions.
- Add references to websites for Yakushima travel information.
- Add detailed itinerary for a trip to Yakushima, including flight details, car rental, hotel check-in, and daily activities.
- Add a section describing Yakushima Island and key notable notes.
- Add a tips section recommending rain gear, car rental, and hiking equipment.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ahandsel/tokyo-geek/pull/15?shareId=3fed9d27-8fa7-4be9-9a02-09623e16520d).