### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vitepress-auto-update.yml
+++ b/.github/workflows/vitepress-auto-update.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   update-vitepress:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Potential fix for [https://github.com/ahandsel/tokyo-geek/security/code-scanning/1](https://github.com/ahandsel/tokyo-geek/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, specifying only the minimum required permissions for the job. Since the workflow pushes commits and creates pull requests, it needs `contents: write` and `pull-requests: write` permissions. The best way to fix this is to add the `permissions` block at the job level (under `update-vitepress:`), so it applies only to this job. This change should be made in `.github/workflows/vitepress-auto-update.yml`, immediately after the job name and before `runs-on:`. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
