### PR TITLE
Update Wise and Revolut referral links

### DIFF
--- a/docs/local/moving/internet-and-cell-service.md
+++ b/docs/local/moving/internet-and-cell-service.md
@@ -56,7 +56,7 @@ As of November 2025:
 
 [matcha-japan-post-bank]: https://matcha-jp.com/en/4496
 [rakuten-credit-card]: https://www.rakuten-card.co.jp/
-[promo-link-wise]: https://wise.com/invite/ihpc/genjif1
+[promo-link-wise]: https://wise.com/invite/ihpn/genjif1
 
 
 ## Notes on cell phone plans in Japan

--- a/docs/tips/china-travel.md
+++ b/docs/tips/china-travel.md
@@ -119,7 +119,7 @@ For detailed setup instructions:
 * [Alipay for tourists][alipay-tourists]
 
 [alipay-tourists]: https://trevallog.com/alipay-for-tourist/
-[promo-link-wise]: https://wise.com/invite/ihpc/genjif1
+[promo-link-wise]: https://wise.com/invite/ihpn/genjif1
 
 
 ## Visa requirements

--- a/docs/tips/europe/europe-travel-ja.md
+++ b/docs/tips/europe/europe-travel-ja.md
@@ -99,7 +99,7 @@ head:
 * **[Revolut]** も便利なので、出発前に登録しておくと安心。
 * **小銭（€1、€2、€5など）を€50程度用意**しておくと、チップや公衆トイレの支払いに役立ちます。
 
-[Revolut]: https://revolut.com/referral/?referral-code=genjikw45!JUL1-25-AR-JP
+[Revolut]: https://revolut.com/referral/?referral-code=genjikw45!JAN1-26-AR-JP-H2&geo-redirect
 
 
 ## 環境と衛生

--- a/docs/tips/europe/index.md
+++ b/docs/tips/europe/index.md
@@ -96,7 +96,7 @@ Specific bags used:
 * **[Revolut][]** is highly recommended - set it up before your trip.
 * Withdraw **about €50 in cash** in small bills (€1, €2, €5) for tipping or cash-only toilet locations.
 
-[Revolut]: https://revolut.com/referral/?referral-code=genjikw45!JUL1-25-AR-JP
+[Revolut]: https://revolut.com/referral/?referral-code=genjikw45!JAN1-26-AR-JP-H2&geo-redirect
 
 
 ## Environment and hygiene

--- a/docs/tips/holding-yen.md
+++ b/docs/tips/holding-yen.md
@@ -120,4 +120,4 @@ A note from an economics enthusiast: locking in market returns can outpace infla
 * [Revolut Review: Checking and Savings - NerdWallet](https://www.nerdwallet.com/reviews/banking/revolut)
 * [Best multi-currency accounts in the US [2023] - Wise](https://wise.com/us/blog/us-foreign-currency-account)
 
-[promo-link-wise]: https://wise.com/invite/ihpc/genjif1
+[promo-link-wise]: https://wise.com/invite/ihpn/genjif1

--- a/docs/tips/us-trip-app.md
+++ b/docs/tips/us-trip-app.md
@@ -32,5 +32,5 @@ Here are iOS apps that I recommend downloading for your trip to the United State
 [Nomad]: https://apps.apple.com/app/id1521602300
 [Revolut]: https://apps.apple.com/app/id932493382
 [Timeshifter]: https://apps.apple.com/app/id1380684374
-[Revolut invite link]: https://revolut.com/referral/?referral-code=genjikw45!FEB1-24-AR-JP
+[Revolut invite link]: https://revolut.com/referral/?referral-code=genjikw45!JAN1-26-AR-JP-H2&geo-redirect
 [Airalo invite code: AB6826]: https://ref.airalo.com/DB2m


### PR DESCRIPTION
### Motivation

- Ensure the repository uses the current Wise and Revolut referral URLs across travel and moving guidance so referral links remain valid and tracked.

### Description

- Replaced Wise invite links to `https://wise.com/invite/ihpn/genjif1` in `docs/local/moving/internet-and-cell-service.md`, `docs/tips/china-travel.md`, and `docs/tips/holding-yen.md`.
- Updated Revolut referral URLs to `https://revolut.com/referral/?referral-code=genjikw45!JAN1-26-AR-JP-H2&geo-redirect` in `docs/tips/us-trip-app.md`, `docs/tips/europe/index.md`, and `docs/tips/europe/europe-travel-ja.md`.
- All changes are textual link updates with no content restructuring or logic changes.

### Testing

- No automated tests were executed because this is a link-only documentation update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69734e1393408333be3b8eb6659964ce)