### PR TITLE
Add Chart.js support via vitepress-plugin-chartjs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,6 +2,12 @@
 
 import { defineConfig } from 'vitepress';
 import { withSidebar } from 'vitepress-sidebar';
+import * as chartjs from 'vitepress-plugin-chartjs';
+
+const chartjsMarkdownPlugin =
+  (chartjs as Record<string, unknown>).chartjsPlugin ??
+  (chartjs as Record<string, unknown>).chartJsPlugin ??
+  (chartjs as Record<string, unknown>).default;
 
 // https://vitepress.dev/reference/site-config
 const vitePressOptions = {
@@ -20,6 +26,13 @@ const vitePressOptions = {
   lastUpdated: true,
   cleanUrls: true,
   metaChunk: true,
+  markdown: {
+    config: (md) => {
+      if (typeof chartjsMarkdownPlugin === 'function') {
+        md.use(chartjsMarkdownPlugin);
+      }
+    },
+  },
 
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,6 +2,8 @@
 import { h } from 'vue';
 import type { Theme } from 'vitepress';
 import DefaultTheme from 'vitepress/theme';
+import 'chart.js/auto';
+import * as chartjs from 'vitepress-plugin-chartjs';
 import './style.css';
 
 // https://nolebase-integrations.ayaka.io/pages/en/integrations/vitepress-plugin-enhanced-readabilities/#add-plugin-specific-options-into-configurations-of-vite
@@ -26,5 +28,32 @@ export default {
       // https://vitepress.dev/guide/extending-default-theme#layout-slots
     });
   },
-  enhanceApp({ app, router, siteData }) {},
+  enhanceApp({ app, router, siteData }) {
+    const installers = [
+      (chartjs as Record<string, unknown>).enhanceAppWithChartJS,
+      (chartjs as Record<string, unknown>).enhanceAppWithChartjs,
+      (chartjs as Record<string, unknown>).enhanceAppWithChart,
+      (chartjs as Record<string, unknown>).enhanceApp,
+      (chartjs as Record<string, unknown>).default,
+    ];
+
+    const installer = installers.find(
+      (candidate) => typeof candidate === 'function',
+    ) as
+      | ((context: {
+          app: unknown;
+          router: unknown;
+          siteData: unknown;
+        }) => void)
+      | ((app: unknown) => void)
+      | undefined;
+
+    if (!installer) return;
+
+    try {
+      installer({ app, router, siteData });
+    } catch {
+      installer(app);
+    }
+  },
 } satisfies Theme;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nolebase/vitepress-plugin-meta": "^2.18.2",
     "@vite-pwa/assets-generator": "^1.0.2",
     "@vite-pwa/vitepress": "^1.1.0",
+    "chart.js": "^4.5.1",
     "gray-matter": "^4.0.3",
     "init": "^0.1.2",
     "js-yaml": "^4.1.1",
@@ -34,6 +35,7 @@
     "vite": "^7.3.1",
     "vite-plugin-pwa": "^1.2.0",
     "vitepress": "2.0.0-alpha.16",
+    "vitepress-plugin-chartjs": "^0.1.6",
     "vitepress-mermaid-renderer": "^1.1.8",
     "vitepress-sidebar": "^1.33.1",
     "vue": "^3.5.28"


### PR DESCRIPTION
### Motivation
- Enable Chart.js-powered charts in the documentation by wiring a VitePress plugin so chart code blocks render in the site.

### Description
- Added `chart.js` and `vitepress-plugin-chartjs` to `devDependencies` in `package.json` so the plugin can be installed and bundled.
- Registered the plugin's markdown transformer in `docs/.vitepress/config.mts` using `markdown.config` so chart code blocks will be processed during Markdown rendering.
- Initialized Chart.js runtime in the custom theme by importing `chart.js/auto` and attempting to invoke the plugin's app installer in `docs/.vitepress/theme/index.ts`, with fallbacks for multiple possible exported installer names.
- Implemented defensive checks so the plugin is only used when the expected export is present to avoid runtime errors when the package is missing or has a different export shape.

### Testing
- Ran `pnpm exec prettier --check docs/.vitepress/config.mts docs/.vitepress/theme/index.ts package.json`, which initially reported formatting issues and then passed after running `pnpm exec prettier --write`.
- Attempted to install the packages with `pnpm add -D vitepress-plugin-chartjs chart.js`, but installation was blocked by the environment registry/proxy returning `ERR_PNPM_FETCH_403`, so the packages were not installed.
- Ran `pnpm build`, which failed with `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vitepress-plugin-chartjs'` because the plugin could not be fetched and installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991fbefc5888333989823a84e06db86)