### PR TITLE
🔧 CodeQL: pin the analyzed language list

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+# .github/workflows/codeql.yml
+# Run CodeQL code scanning against an explicit, pinned list of languages
+# Triggered on pushes to main, pull requests targeting main, every Monday, or the "Run workflow" button
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main] # Keep the Security tab baseline for the default branch current
+  pull_request:
+    branches: [main] # Surface new alerts on the pull request before it merges
+  schedule:
+    - cron: '15 22 * * 1' # Runs every Monday at 22:15 UTC, the slot the default setup used
+  workflow_dispatch: {} # Allow manual execution from the GitHub Actions tab
+
+permissions:
+  contents: read
+
+# Supersede queued pull request runs, but let every push to main finish so the baseline stays complete
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read # actions/checkout reads the repository
+      security-events: write # github/codeql-action/analyze uploads results to the Security tab
+
+    strategy:
+      fail-fast: false # A failure in one language must not discard the results of the other
+      matrix:
+        # This list is the whole point of the workflow: CodeQL analyzes exactly these two languages,
+        # so auto-detection can never add one that this repository does not contain.
+        # `actions` covers the workflow files, and `javascript-typescript` covers the .mjs, .ts, .mts,
+        # and .vue sources under contents/ and scripts/.
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      # Step 1: Checkout repository code (CodeQL only reads the source, so no credentials are needed)
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # actions/checkout@v5.0.0, pinned
+        with:
+          persist-credentials: false
+
+      # Step 2: Build the CodeQL database for this language
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # github/codeql-action@v4.37.7, pinned
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # Step 3: Run the default query suite and upload the results
+      # The category must stay `/language:<name>` so alert history from the default setup carries over
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # github/codeql-action@v4.37.7, pinned
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Problem

The CodeQL tool status page reported an error for the automatic (default setup) configuration.

The cause was a single stale analysis, not a real scanning failure:

| Field | Value |
| --- | --- |
| Analysis ID | `1343159003` |
| Category | `/language:ruby` |
| Ref | `refs/heads/main` (commit `b272336`) |
| Created | 2026-06-09 |
| Error | `unsuccessful execution, exit code: 0` |
| Results / rules | 0 / 0 |

No `.rb`, `Gemfile`, `.gemspec`, or `.ruby-version` file has ever existed in this repository's history. GitHub's language auto-detection misfired, the Ruby extraction found no source, and it failed. Because Ruby was later dropped from the configured language list, nothing would ever re-run `/language:ruby` to overwrite that stored error, so it persisted on the status page.

That stale analysis has been deleted. Of 368 total analyses it was the only record with a non-empty `error` field.

## Root cause

Deleting the analysis clears the symptom but not the cause. With default setup disabled, the API still reports the auto-detected candidate list as:

```json
["actions", "javascript", "javascript-typescript", "ruby", "typescript"]
```

GitHub still believes this repository contains Ruby, so a future re-detection could reintroduce the same failing configuration.

## Fix

Replace default setup with an advanced setup workflow that pins the language list explicitly, so auto-detection cannot add a language this repository does not contain.

- Matrix pinned to `actions` and `javascript-typescript`, both with `build-mode: none`. This mirrors what default setup already ran, per the stored `environment` field on the existing analyses.
- Category kept as `/language:<name>`, matching the existing categories so alert history carries over rather than forking into a new configuration.
- `github/codeql-action` pinned to v4.37.7 by commit SHA, following the SHA pinning convention used by the other three workflows. Dependabot's `github-actions` ecosystem entry will keep it current.
- Least privilege: `security-events: write` plus `contents: read`. `actions: read` and `packages: read` are not needed because this repository is public and the default query suite uses no private packs.
- `cancel-in-progress` is conditional, so superseded pull request runs are cancelled while every push to `main` finishes and the default branch baseline stays complete.
- Weekly cron at 22:15 UTC on Monday, matching the slot default setup was already using.

## Verification

| Check | Result |
| --- | --- |
| `pnpm lint` | Exit 0, no files modified |
| `prettier --check` | All matched files use Prettier code style |
| `actionlint` | No issues |
| `zizmor` | No findings to report |

## Note

Code scanning default setup has already been set to `not-configured`, because GitHub rejects SARIF uploads from an advanced workflow while default setup is enabled. The CodeQL run on this pull request is therefore the first real test of the new workflow.

There were 0 open code scanning alerts before this change, so no alert data was at stake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
